### PR TITLE
Fix/oniwa/00/add bottom padding

### DIFF
--- a/web/src/app/groups/[groupId]/manage/page.tsx
+++ b/web/src/app/groups/[groupId]/manage/page.tsx
@@ -71,7 +71,7 @@ export default function GroupManagementPage({ params }: PageProps) {
 
   return (
     <div className="bg-white min-h-screen">
-      <div className="px-4 pb-10">
+      <div className="px-4 pb-[200px]">
         
         {/* 1. settingページと同じModalHeaderを使用 */}
         <ModalHeader />

--- a/web/src/app/groups/[groupId]/manage/page.tsx
+++ b/web/src/app/groups/[groupId]/manage/page.tsx
@@ -71,7 +71,7 @@ export default function GroupManagementPage({ params }: PageProps) {
 
   return (
     <div className="bg-white min-h-screen">
-      <div className="px-4 pb-[200px]">
+      <div className="px-4 pb-8">
         
         {/* 1. settingページと同じModalHeaderを使用 */}
         <ModalHeader />

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <div className="pb-8">
+        <div className="pb-[250px]">
         {children}
         </div>
       </body>

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -27,7 +27,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <div className="pb-8">
         {children}
+        </div>
       </body>
     </html>
   );


### PR DESCRIPTION
グループ内管理画面の最下部がフッターで隠れないようにpbを修正しました
<img width="451" height="383" alt="image" src="https://github.com/user-attachments/assets/2e197a4c-de04-4325-80fc-02cdfc6dd2b5" />

- [ ] http://localhost:3000/groups/1/manage　でボタンがフッターに隠れないか