### PR TITLE
[fix] setting画面とAPIのつなぎこみ

### DIFF
--- a/api/internal/repository/group.go
+++ b/api/internal/repository/group.go
@@ -61,29 +61,45 @@ func (r *GroupRepository) OwnsAny(ctx context.Context, ownerID string) (bool, er
 	return exists, err
 }
 
-// 更新頻度を取得
+// 追加：名称取得・更新
+func (r *GroupRepository) GetName(ctx context.Context, groupID string) (string, error) {
+	var name string
+	err := r.DB.QueryRowContext(ctx, `SELECT name FROM groups WHERE id = $1`, groupID).Scan(&name)
+	return name, err
+}
+
+func (r *GroupRepository) UpdateName(ctx context.Context, groupID, name string) error {
+	res, err := r.DB.ExecContext(ctx, `UPDATE groups SET name = $2 WHERE id = $1`, groupID, name)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// 更新頻度取得・更新（現状踏襲）
 func (r *GroupRepository) GetRefreshIntervalHours(ctx context.Context, groupID string) (int, error) {
 	var h int
 	err := r.DB.QueryRowContext(ctx, `
-		SELECT refresh_interval_hours
+		SELECT refresh_interval_hours::int
 		  FROM groups
 		 WHERE id = $1
 	`, groupID).Scan(&h)
 	return h, err
 }
 
-// 更新頻度を変更
 func (r *GroupRepository) UpdateRefreshIntervalHours(ctx context.Context, groupID string, hours int) error {
 	_, err := r.DB.ExecContext(ctx, `
 UPDATE groups
-   SET refresh_interval_hours = $1,
+   SET refresh_interval_hours = $1::smallint,
        next_refresh_at = refreshed_at + make_interval(hours => $1)
  WHERE id = $2
 `, hours, groupID)
 	return err
 }
 
-// 期限到来のグループを取得（いま更新すべきもの）
 func (r *GroupRepository) FindDueGroups(ctx context.Context, limit int) ([]string, error) {
 	const q = `
 SELECT id
@@ -109,7 +125,6 @@ SELECT id
 	return ids, rows.Err()
 }
 
-// Refresh実行後にrefreshed_atを刻む
 func (r *GroupRepository) TouchRefreshedAt(ctx context.Context, groupID string) error {
 	_, err := r.DB.ExecContext(ctx, `
 UPDATE groups
@@ -120,7 +135,6 @@ UPDATE groups
 	return err
 }
 
-// groups.track_id を1曲だけ更新（nilでクリアも可）
 func (r *GroupRepository) UpdateTrackID(ctx context.Context, groupID string, trackID *string) error {
 	const q = `UPDATE groups SET track_id = $2 WHERE id = $1;`
 	res, err := r.DB.ExecContext(ctx, q, groupID, trackID)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   web:
     build: ./web
     ports:
-      - "3001:3000"
+      - "3000:3000"
     volumes:
       - ./web:/app
     environment:

--- a/web/src/app/setting/page.tsx
+++ b/web/src/app/setting/page.tsx
@@ -1,60 +1,147 @@
 "use client";
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import ModalHeader from '@/components/ModalHeader';
 import UsernameChangeSection from '@/components/UsernameChangeSection';
 import JoinGroupSection from '@/components/JoinGroupSection';
 import CreateGroupSection from '@/components/CreateGroupSection';
 import AccountManagementSection from '@/components/AccountManagementSection';
-import AppLogo from '@/components/AppLogo';
 import Footer from '@/components/footer/Footer';
 
 export default function SettingPage() {
+  const router = useRouter();
+
   // --- 状態管理 ---
-  const [username, setUsername] = useState('えねも えね男'); // 初期値はAPIから取得
+  const [username, setUsername] = useState('');
+  const [initialUsername, setInitialUsername] = useState(''); // 更新失敗時に戻すための初期値
   const [groupId, setGroupId] = useState('');
   const [newGroupName, setNewGroupName] = useState('');
-  const [updateFrequency, setUpdateFrequency] = useState('daily');
+  const [updateFrequency, setUpdateFrequency] = useState('daily'); // この値は現在APIでは使用されません
+
+  // --- 初期データ取得 ---
+  useEffect(() => {
+    const fetchUserData = async () => {
+      try {
+        const response = await fetch('/api/v1/users/me', { credentials: 'include' });
+        if (!response.ok) {
+          // 認証エラーなどの場合はログインページにリダイレクト
+          router.push('/login');
+          return;
+        }
+        const userData = await response.json();
+        setUsername(userData.display_name);
+        setInitialUsername(userData.display_name);
+      } catch (error) {
+        console.error('Failed to fetch user data:', error);
+        alert('ユーザー情報の取得に失敗しました。');
+      }
+    };
+    fetchUserData();
+  }, [router]);
 
   // --- イベントハンドラ ---
-  const handleUsernameChange = () => {
-    // TODO: ユーザー名変更APIを呼び出す
-    alert(`ユーザー名を「${username}」に変更します。`);
+  const handleUsernameChange = async () => {
+    try {
+      const response = await fetch('/api/v1/users/rename', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ display_name: username }),
+      });
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'ユーザー名の変更に失敗しました。');
+      }
+      const updatedUser = await response.json();
+      setInitialUsername(updatedUser.display_name);
+      alert('ユーザー名を変更しました。');
+    } catch (error) {
+      console.error('Error updating username:', error);
+      alert(error instanceof Error ? error.message : 'エラーが発生しました。');
+      setUsername(initialUsername); // 失敗したら元の名前に戻す
+    }
   };
 
-  const handleJoinGroup = () => {
-    // TODO: グループ参加APIを呼び出す
+  const handleJoinGroup = async () => {
     if (!groupId) {
       alert('グループIDを入力してください。');
       return;
     }
-    alert(`グループID「${groupId}」に参加します。`);
+    try {
+      const response = await fetch('/api/v1/groups/add', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ group_id: groupId }),
+      });
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'グループへの参加に失敗しました。');
+      }
+      alert(`グループID「${groupId}」に参加しました。`);
+      setGroupId('');
+      router.push('/groups'); // グループ一覧ページに遷移
+    } catch (error) {
+      console.error('Error joining group:', error);
+      alert(error instanceof Error ? error.message : 'エラーが発生しました。');
+    }
   };
 
-  const handleCreateGroup = () => {
-    // TODO: グループ作成APIを呼び出す
+  const handleCreateGroup = async () => {
     if (!newGroupName) {
       alert('グループ名を入力してください。');
       return;
     }
-    alert(`グループ名「${newGroupName}」で作成します。\n更新頻度: ${updateFrequency}`);
-  };
-
-  const handleLogout = () => {
-    // TODO: ログアウト処理
-    if (confirm('本当にログアウトしますか？')) {
-      alert('ログアウトしました。');
-      // 例: ログインページにリダイレクト
-      // router.push('/login');
+    try {
+      const response = await fetch('/api/v1/groups/make', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ name: newGroupName }),
+      });
+      if (response.status !== 201) { // 201 Created を期待
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'グループの作成に失敗しました。');
+      }
+      const newGroup = await response.json();
+      alert(`グループ「${newGroup.name}」を作成しました。`);
+      setNewGroupName('');
+      router.push('/groups'); // グループ一覧ページに遷移
+    } catch (error) {
+      console.error('Error creating group:', error);
+      alert(error instanceof Error ? error.message : 'エラーが発生しました。');
     }
   };
 
-  const handleDeleteAccount = () => {
-    // TODO: アカウント削除処理
+  const handleLogout = async () => {
+    if (confirm('本当にログアウトしますか？')) {
+      try {
+        const response = await fetch('/api/v1/users/logout', { method: 'POST', credentials: 'include' });
+        if (!response.ok) throw new Error('ログアウトに失敗しました。');
+        alert('ログアウトしました。');
+        router.push('/login');
+      } catch (error) {
+        console.error('Logout error:', error);
+        alert(error instanceof Error ? error.message : 'エラーが発生しました。');
+      }
+    }
+  };
+
+  const handleDeleteAccount = async () => {
     if (confirm('アカウントを削除すると元に戻せません。本当に削除しますか？')) {
-      alert('アカウントを削除しました。');
-      // 例: トップページなどにリダイレクト
-      // router.push('/');
+      try {
+        const response = await fetch('/api/v1/users/delete', { method: 'POST', credentials: 'include' });
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(errorData.error || 'アカウントの削除に失敗しました。');
+        }
+        alert('アカウントを削除しました。');
+        router.push('/');
+      } catch (error) {
+        console.error('Delete account error:', error);
+        alert(error instanceof Error ? error.message : 'エラーが発生しました。');
+      }
     }
   };
 
@@ -63,7 +150,7 @@ export default function SettingPage() {
       <div className="max-w-md mx-auto px-4">
         <ModalHeader />
         <div className="pt-10">
-            <h1 className="text-4xl text-black font-bold text-center">Setting</h1>
+          <h1 className="text-4xl text-black font-bold text-center">Setting</h1>
         </div>
         <main className="space-y-10 py-4">
           <UsernameChangeSection
@@ -71,13 +158,11 @@ export default function SettingPage() {
             onUsernameChange={(e) => setUsername(e.target.value)}
             onSubmit={handleUsernameChange}
           />
-
           <JoinGroupSection
             groupId={groupId}
             onGroupIdChange={(e) => setGroupId(e.target.value)}
             onSubmit={handleJoinGroup}
           />
-          
           <CreateGroupSection
             groupName={newGroupName}
             onGroupNameChange={(e) => setNewGroupName(e.target.value)}
@@ -85,12 +170,10 @@ export default function SettingPage() {
             onFrequencyChange={(e) => setUpdateFrequency(e.target.value)}
             onSubmit={handleCreateGroup}
           />
-
           <AccountManagementSection
             onLogout={handleLogout}
             onDeleteAccount={handleDeleteAccount}
           />
-          
         </main>
         <Footer />
       </div>

--- a/web/src/app/setting/page.tsx
+++ b/web/src/app/setting/page.tsx
@@ -9,6 +9,21 @@ import CreateGroupSection from '@/components/CreateGroupSection';
 import AccountManagementSection from '@/components/AccountManagementSection';
 import Footer from '@/components/footer/Footer';
 
+// Helper function to convert frequency string to hours
+const frequencyToHours = (freq: string): number => {
+  switch (freq) {
+    case '12h': return 12;
+    case '1d': return 24;
+    case '2d': return 48;
+    case '3d': return 72;
+    case '4d': return 96;
+    case '5d': return 120;
+    case '6d': return 144;
+    case '7d': return 168;
+    default: return 24; // Default to 1 day (24 hours)
+  }
+};
+
 export default function SettingPage() {
   const router = useRouter();
 
@@ -17,7 +32,7 @@ export default function SettingPage() {
   const [initialUsername, setInitialUsername] = useState(''); // 更新失敗時に戻すための初期値
   const [groupId, setGroupId] = useState('');
   const [newGroupName, setNewGroupName] = useState('');
-  const [updateFrequency, setUpdateFrequency] = useState('daily'); // この値は現在APIでは使用されません
+  const [updateFrequency, setUpdateFrequency] = useState('1d'); // API仕様に合わせて初期値を'1d'に変更
 
   // --- 初期データ取得 ---
   useEffect(() => {
@@ -94,20 +109,42 @@ export default function SettingPage() {
       return;
     }
     try {
-      const response = await fetch('/api/v1/groups/make', {
+      // 1. グループを作成
+      const createResponse = await fetch('/api/v1/groups/make', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         body: JSON.stringify({ name: newGroupName }),
       });
-      if (response.status !== 201) { // 201 Created を期待
-        const errorData = await response.json();
+
+      if (createResponse.status !== 201) { // 201 Created を期待
+        const errorData = await createResponse.json();
         throw new Error(errorData.error || 'グループの作成に失敗しました。');
       }
-      const newGroup = await response.json();
+      const newGroup = await createResponse.json();
+      
+      // 2. 作成したグループの更新頻度を設定
+      const hours = frequencyToHours(updateFrequency);
+      const updateResponse = await fetch('/api/v1/groups/settings/update', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+              group_id: newGroup.id,
+              refresh_interval_hours: hours,
+          }),
+      });
+
+      if (!updateResponse.ok) {
+        // 更新頻度の設定に失敗してもグループ作成は成功しているので、その旨を伝える
+        const errorData = await updateResponse.json();
+        throw new Error(`グループは作成されましたが、更新頻度の設定に失敗しました: ${errorData.error}`);
+      }
+
       alert(`グループ「${newGroup.name}」を作成しました。`);
       setNewGroupName('');
       router.push('/groups'); // グループ一覧ページに遷移
+
     } catch (error) {
       console.error('Error creating group:', error);
       alert(error instanceof Error ? error.message : 'エラーが発生しました。');


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #77 

# 概要
<!-- 開発内容の概要を記載 -->
一般設定画面とAPIのつなぎこみを行った

# 実装詳細
<!-- 具体的な開発内容を記載 -->


# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] 
テスト方法
AとBの2つのユーザーがいたと仮定する
* Aが新規登録
* Aがログイン
* Aがhttp://localhost:3001/settingでユーザー名を変更
* 一度groups画面にバックボタンで戻り，再度setting画面に行きユーザー名変更が反映されているか確認
* Aがhttp://localhost:3001/settingで新規グループ作成
* 作成したグループのグループID(URLの最後のやつ)をコピーしておく
* Aをログアウトする
* Bの新規登録
* Bのログイン
* setting画面からグループに参加で先ほどコピーしたグループIDを使い参加
* グループに参加できてるか確認
# 備考
<!-- 実装していて困った箇所・質問など -->