### PR TITLE
[add] ログインユーザーのグループID把握

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ db-group_members:
 	docker compose exec db psql -U enomo -d enomo_dev -c "SELECT * FROM group_members"
 db-sessions:
 	docker compose exec db psql -U enomo -d enomo_dev -c "SELECT * FROM sessions"
+db-user_active_groups:
+	docker compose exec db psql -U enomo -d enomo_dev -c "SELECT * FROM user_active_groups"
 
-refresh-web:
-	docker compose restart web
-	docker compose logs -f web
+restart:
+	docker compose up --build -d

--- a/api/cmd/main.go
+++ b/api/cmd/main.go
@@ -36,6 +36,7 @@ func main() {
 	groupRepo := repository.NewGroupRepository(db)
 	memberRepo := repository.NewGroupMemberRepository(db)
 	store := repository.NewPostgresTokenStore(db)
+	activeRepo := repository.NewActiveGroupRepository(db)
 	energyRepo := repository.NewGroupEnergyRepository(db)
 	spotifyClient := repository.NewMockSpotify() // 本番は実Spotifyクライアントに差し替え
 
@@ -48,6 +49,7 @@ func main() {
 	renameUC := usecase.NewUserUpdateDisplayNameUsecase(userRepo)
 	energyUC := usecase.NewUserUpdateEnergyValueUsecase(userRepo)
 	udelUC := usecase.NewUserDeleteUsecase(userRepo, groupRepo)
+	nowUC := usecase.NewGroupNowUsecase(activeRepo, memberRepo)
 	makeUC := usecase.NewGroupMakeUsecase(groupRepo, memberRepo)
 	addUC := usecase.NewGroupAddUsecase(memberRepo)
 	ulistUC := usecase.NewGroupListUsecase(memberRepo, userRepo)
@@ -66,6 +68,7 @@ func main() {
 	renameH := domain.NewUserRenameHandler(renameUC, store)
 	energyH := domain.NewUserEnergyHandler(energyUC, store)
 	udelH := domain.NewUserDeleteHandler(udelUC, store)
+	nowH := domain.NewGroupNowHandler(nowUC, store)
 	makeH := domain.NewGroupMakeHandler(makeUC, store)
 	addH := domain.NewGroupAddHandler(addUC, store)
 	ulistH := domain.NewGroupListHandler(ulistUC)
@@ -84,6 +87,7 @@ func main() {
 		renameH,
 		energyH,
 		udelH,
+		nowH,
 		makeH,
 		addH,
 		ulistH,

--- a/api/cmd/main.go
+++ b/api/cmd/main.go
@@ -57,7 +57,7 @@ func main() {
 	leaveUC := usecase.NewGroupLeaveUsecase(memberRepo, groupRepo)
 	recoUC := usecase.NewRecommendationsUsecase(energyRepo, spotifyClient)
 	recoRefreshUC := usecase.NewRecommendationsRefreshUsecase(energyRepo, spotifyClient, groupRepo)
-	settingsUC := usecase.NewGroupSettingsUsecase(groupRepo /*, memberRepo*/)
+	settingsUC := usecase.NewGroupSettingsUsecase(groupRepo)
 
 	// --- handlers ---
 	meH := domain.NewUserMeHandler(meUC, store)

--- a/api/internal/domain/group_now_handler.go
+++ b/api/internal/domain/group_now_handler.go
@@ -1,0 +1,90 @@
+package domain
+
+import (
+	"enomo/api/internal/repository"
+	"enomo/api/internal/usecase"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+type GroupNowHandler struct {
+	uc    *usecase.GroupNowUsecase
+	store repository.TokenStore
+}
+
+func NewGroupNowHandler(uc *usecase.GroupNowUsecase, store repository.TokenStore) *GroupNowHandler {
+	return &GroupNowHandler{uc: uc, store: store}
+}
+
+type setBody struct {
+	GroupID string `json:"group_id"`
+}
+
+func (h *GroupNowHandler) Set(c echo.Context) error {
+	ck, err := c.Cookie("session_token")
+	if err != nil || ck.Value == "" {
+		return c.JSON(http.StatusUnauthorized, echo.Map{"error": "unauthorized"})
+	}
+	userID, ok, err := h.store.Get(ck.Value)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "session error"})
+	}
+	if !ok || userID == "" {
+		return c.JSON(http.StatusUnauthorized, echo.Map{"error": "invalid session"})
+	}
+
+	var in setBody
+	if err := c.Bind(&in); err != nil || in.GroupID == "" {
+		return c.JSON(http.StatusBadRequest, echo.Map{"error": "group_id required"})
+	}
+	if err := h.uc.Set(c.Request().Context(), usecase.GroupNowSetRequest{UserID: userID, GroupID: in.GroupID}); err != nil {
+		if err == usecase.ErrNotGroupMember {
+			return c.JSON(http.StatusForbidden, echo.Map{"error": "not a group member"})
+		}
+		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "failed to set"})
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+func (h *GroupNowHandler) Get(c echo.Context) error {
+	ck, err := c.Cookie("session_token")
+	if err != nil || ck.Value == "" {
+		return c.JSON(http.StatusUnauthorized, echo.Map{"error": "unauthorized"})
+	}
+	userID, ok, err := h.store.Get(ck.Value)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "session error"})
+	}
+	if !ok || userID == "" {
+		return c.JSON(http.StatusUnauthorized, echo.Map{"error": "invalid session"})
+	}
+
+	out, err := h.uc.Get(c.Request().Context(), userID)
+	if err != nil {
+		if err == usecase.ErrActiveGroupNotSet {
+			return c.JSON(http.StatusNotFound, echo.Map{"error": "active group not set"})
+		}
+		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "failed to get"})
+	}
+	return c.JSON(http.StatusOK, out)
+}
+
+func (h *GroupNowHandler) Clear(c echo.Context) error {
+	ck, err := c.Cookie("session_token")
+	if err != nil || ck.Value == "" {
+		return c.JSON(http.StatusUnauthorized, echo.Map{"error": "unauthorized"})
+	}
+	userID, ok, err := h.store.Get(ck.Value)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "session error"})
+	}
+	if !ok || userID == "" {
+		return c.JSON(http.StatusUnauthorized, echo.Map{"error": "invalid session"})
+	}
+
+	if err := h.uc.Clear(c.Request().Context(), userID); err != nil {
+		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "failed to clear"})
+	}
+	return c.NoContent(http.StatusNoContent)
+}

--- a/api/internal/domain/group_settings_handler.go
+++ b/api/internal/domain/group_settings_handler.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"net/http"
+	"strings"
 
 	"enomo/api/internal/repository"
 	"enomo/api/internal/usecase"
@@ -11,7 +12,11 @@ import (
 
 type GroupSettingsHandler struct {
 	UC    usecase.GroupSettingsUsecase
-	store repository.TokenStore
+	store TokenStore
+}
+
+type TokenStore interface {
+	Get(token string) (userID string, ok bool, err error)
 }
 
 func NewGroupSettingsHandler(uc usecase.GroupSettingsUsecase, store repository.TokenStore) *GroupSettingsHandler {
@@ -21,30 +26,37 @@ func NewGroupSettingsHandler(uc usecase.GroupSettingsUsecase, store repository.T
 // GET /api/v1/groups/settings?group_id=...
 func (h *GroupSettingsHandler) Get(c echo.Context) error {
 	groupID := c.QueryParam("group_id")
-	if groupID == "" {
+	if strings.TrimSpace(groupID) == "" {
 		return c.JSON(http.StatusBadRequest, map[string]any{"error": "group_id is required"})
 	}
-	hours, err := h.UC.GetHours(c.Request().Context(), groupID)
+	out, err := h.UC.Get(c.Request().Context(), groupID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]any{"error": "failed_to_get_settings"})
 	}
 	return c.JSON(http.StatusOK, map[string]any{
-		"group_id":               groupID,
-		"refresh_interval_hours": hours,
+		"group_id":               out.GroupID,
+		"group_name":             out.GroupName,
+		"refresh_interval_hours": out.RefreshIntervalHours,
 	})
 }
 
 type updateReq struct {
-	GroupID string `json:"group_id"`
-	Hours   int    `json:"refresh_interval_hours"`
+	GroupID              string  `json:"group_id"`
+	GroupName            *string `json:"group_name,omitempty"`
+	RefreshIntervalHours *int    `json:"refresh_interval_hours,omitempty"`
 }
 
 // POST /api/v1/groups/settings/update
 func (h *GroupSettingsHandler) Update(c echo.Context) error {
 	var req updateReq
-	if err := c.Bind(&req); err != nil || req.GroupID == "" {
+	if err := c.Bind(&req); err != nil || strings.TrimSpace(req.GroupID) == "" {
 		return c.JSON(http.StatusBadRequest, map[string]any{"error": "invalid_request"})
 	}
+	// どちらも指定なしは NG
+	if req.GroupName == nil && req.RefreshIntervalHours == nil {
+		return c.JSON(http.StatusBadRequest, map[string]any{"error": "no_fields_to_update"})
+	}
+
 	actor := ""
 	if ck, err := c.Cookie("session_token"); err == nil && ck.Value != "" {
 		if uid, ok, err := h.store.Get(ck.Value); err == nil && ok {
@@ -55,9 +67,17 @@ func (h *GroupSettingsHandler) Update(c echo.Context) error {
 		return c.JSON(http.StatusUnauthorized, map[string]any{"error": "unauthorized"})
 	}
 
-	hours, err := h.UC.UpdateHours(c.Request().Context(), req.GroupID, req.Hours, actor)
+	out, err := h.UC.Update(c.Request().Context(), usecase.UpdateGroupSettingsInput{
+		GroupID:              req.GroupID,
+		GroupName:            req.GroupName,
+		RefreshIntervalHours: req.RefreshIntervalHours,
+	}, actor)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})
 	}
-	return c.JSON(http.StatusOK, map[string]any{"group_id": req.GroupID, "refresh_interval_hours": hours})
+	return c.JSON(http.StatusOK, map[string]any{
+		"group_id":               out.GroupID,
+		"group_name":             out.GroupName,
+		"refresh_interval_hours": out.RefreshIntervalHours,
+	})
 }

--- a/api/internal/repository/active_group.go
+++ b/api/internal/repository/active_group.go
@@ -1,0 +1,30 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+)
+
+type ActiveGroupRepository struct{ DB *sql.DB }
+
+func NewActiveGroupRepository(db *sql.DB) *ActiveGroupRepository {
+	return &ActiveGroupRepository{DB: db}
+}
+
+func (r *ActiveGroupRepository) Set(ctx context.Context, userID, groupID string) error {
+	_, err := r.DB.ExecContext(ctx, `
+		INSERT INTO user_active_groups (user_id, group_id)
+		VALUES ($1, $2)
+		ON CONFLICT (user_id) DO UPDATE SET group_id = EXCLUDED.group_id, updated_at = now()
+	`, userID, groupID)
+	return err
+}
+func (r *ActiveGroupRepository) Get(ctx context.Context, userID string) (string, error) {
+	var gid string
+	err := r.DB.QueryRowContext(ctx, `SELECT group_id FROM user_active_groups WHERE user_id = $1`, userID).Scan(&gid)
+	return gid, err
+}
+func (r *ActiveGroupRepository) Clear(ctx context.Context, userID string) error {
+	_, err := r.DB.ExecContext(ctx, `DELETE FROM user_active_groups WHERE user_id = $1`, userID)
+	return err
+}

--- a/api/internal/repository/group.go
+++ b/api/internal/repository/group.go
@@ -61,29 +61,45 @@ func (r *GroupRepository) OwnsAny(ctx context.Context, ownerID string) (bool, er
 	return exists, err
 }
 
-// 更新頻度を取得
+// 追加：名称取得・更新
+func (r *GroupRepository) GetName(ctx context.Context, groupID string) (string, error) {
+	var name string
+	err := r.DB.QueryRowContext(ctx, `SELECT name FROM groups WHERE id = $1`, groupID).Scan(&name)
+	return name, err
+}
+
+func (r *GroupRepository) UpdateName(ctx context.Context, groupID, name string) error {
+	res, err := r.DB.ExecContext(ctx, `UPDATE groups SET name = $2 WHERE id = $1`, groupID, name)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// 更新頻度取得・更新（現状踏襲）
 func (r *GroupRepository) GetRefreshIntervalHours(ctx context.Context, groupID string) (int, error) {
 	var h int
 	err := r.DB.QueryRowContext(ctx, `
-		SELECT refresh_interval_hours
+		SELECT refresh_interval_hours::int
 		  FROM groups
 		 WHERE id = $1
 	`, groupID).Scan(&h)
 	return h, err
 }
 
-// 更新頻度を変更
 func (r *GroupRepository) UpdateRefreshIntervalHours(ctx context.Context, groupID string, hours int) error {
 	_, err := r.DB.ExecContext(ctx, `
 UPDATE groups
-   SET refresh_interval_hours = $1,
+   SET refresh_interval_hours = $1::smallint,
        next_refresh_at = refreshed_at + make_interval(hours => $1)
  WHERE id = $2
 `, hours, groupID)
 	return err
 }
 
-// 期限到来のグループを取得（いま更新すべきもの）
 func (r *GroupRepository) FindDueGroups(ctx context.Context, limit int) ([]string, error) {
 	const q = `
 SELECT id
@@ -109,7 +125,6 @@ SELECT id
 	return ids, rows.Err()
 }
 
-// Refresh実行後にrefreshed_atを刻む
 func (r *GroupRepository) TouchRefreshedAt(ctx context.Context, groupID string) error {
 	_, err := r.DB.ExecContext(ctx, `
 UPDATE groups
@@ -120,7 +135,6 @@ UPDATE groups
 	return err
 }
 
-// groups.track_id を1曲だけ更新（nilでクリアも可）
 func (r *GroupRepository) UpdateTrackID(ctx context.Context, groupID string, trackID *string) error {
 	const q = `UPDATE groups SET track_id = $2 WHERE id = $1;`
 	res, err := r.DB.ExecContext(ctx, q, groupID, trackID)

--- a/api/internal/repository/group_member.go
+++ b/api/internal/repository/group_member.go
@@ -121,3 +121,19 @@ func (r *GroupMemberRepository) IsMember(ctx context.Context, groupID, userID st
 	}
 	return true, isAdmin, nil
 }
+
+func (r *GroupMemberRepository) ExistsByUserAndGroup(ctx context.Context, userID, groupID string) (bool, error) {
+	exists, _, err := r.IsMember(ctx, groupID, userID)
+	return exists, err
+}
+
+func (r *GroupMemberRepository) IsAdmin(ctx context.Context, groupID, userID string) (bool, error) {
+	exists, isAdmin, err := r.IsMember(ctx, groupID, userID)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		return false, nil
+	}
+	return isAdmin, nil
+}

--- a/api/internal/router/router.go
+++ b/api/internal/router/router.go
@@ -16,6 +16,7 @@ func New(
 	rename *domain.UserRenameHandler,
 	energy *domain.UserEnergyHandler,
 	delete *domain.UserDeleteHandler,
+	groupNow *domain.GroupNowHandler,
 	groupMake *domain.GroupMakeHandler,
 	groupAdd *domain.GroupAddHandler,
 	groupList *domain.GroupListHandler,
@@ -41,6 +42,9 @@ func New(
 	api.POST("/users/delete", delete.Delete)
 
 	// groups
+	api.POST("/groups/now", groupNow.Set)
+	api.GET("/groups/now", groupNow.Get)
+	api.DELETE("/groups/now", groupNow.Clear)
 	api.POST("/groups/make", groupMake.Make)
 	api.POST("/groups/add", groupAdd.Add)
 	api.GET("/groups/list", groupList.List)

--- a/api/internal/usecase/group_now_usecase.go
+++ b/api/internal/usecase/group_now_usecase.go
@@ -1,0 +1,57 @@
+package usecase
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"enomo/api/internal/repository"
+)
+
+var (
+	ErrActiveGroupNotSet = errors.New("active group not set")
+	ErrNotGroupMember    = errors.New("user is not a member of the group")
+)
+
+type GroupNowSetRequest struct {
+	UserID  string
+	GroupID string
+}
+type GroupNowResponse struct {
+	GroupID string `json:"group_id"`
+}
+
+type GroupNowUsecase struct {
+	activeRepo *repository.ActiveGroupRepository
+	memberRepo *repository.GroupMemberRepository
+}
+
+func NewGroupNowUsecase(active *repository.ActiveGroupRepository, member *repository.GroupMemberRepository) *GroupNowUsecase {
+	return &GroupNowUsecase{activeRepo: active, memberRepo: member}
+}
+
+func (u *GroupNowUsecase) Set(ctx context.Context, in GroupNowSetRequest) error {
+	ok, err := u.memberRepo.ExistsByUserAndGroup(ctx, in.UserID, in.GroupID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return ErrNotGroupMember
+	}
+	return u.activeRepo.Set(ctx, in.UserID, in.GroupID)
+}
+
+func (u *GroupNowUsecase) Get(ctx context.Context, userID string) (GroupNowResponse, error) {
+	gid, err := u.activeRepo.Get(ctx, userID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return GroupNowResponse{}, ErrActiveGroupNotSet
+		}
+		return GroupNowResponse{}, err
+	}
+	return GroupNowResponse{GroupID: gid}, nil
+}
+
+func (u *GroupNowUsecase) Clear(ctx context.Context, userID string) error {
+	return u.activeRepo.Clear(ctx, userID)
+}

--- a/api/internal/usecase/group_setting_usecase.go
+++ b/api/internal/usecase/group_setting_usecase.go
@@ -3,23 +3,110 @@ package usecase
 import (
 	"context"
 	"errors"
+	"strings"
+	"unicode/utf8"
 
 	"enomo/api/internal/repository"
 )
 
 type GroupSettingsUsecase interface {
+	// 追加：両方まとめて取得
+	Get(ctx context.Context, groupID string) (GroupSettings, error)
+	// 追加：片方または両方を更新
+	Update(ctx context.Context, in UpdateGroupSettingsInput, actorUserID string) (GroupSettings, error)
+
+	// 互換：従来の呼び出しがあれば生かしておく
 	GetHours(ctx context.Context, groupID string) (int, error)
 	UpdateHours(ctx context.Context, groupID string, hours int, actorUserID string) (int, error)
 }
 
 type groupSettingsUsecase struct {
 	groups *repository.GroupRepository
-	// members *repository.GroupMemberRepository // 必要なら管理者チェックに
+	// members *repository.GroupMemberRepository // 権限チェックを広げるならここに足す
 }
 
 func NewGroupSettingsUsecase(g *repository.GroupRepository) GroupSettingsUsecase {
 	return &groupSettingsUsecase{groups: g}
 }
+
+type GroupSettings struct {
+	GroupID              string
+	GroupName            string
+	RefreshIntervalHours int
+}
+
+type UpdateGroupSettingsInput struct {
+	GroupID              string
+	GroupName            *string
+	RefreshIntervalHours *int
+}
+
+// --- read ---
+
+func (u *groupSettingsUsecase) Get(ctx context.Context, groupID string) (GroupSettings, error) {
+	if strings.TrimSpace(groupID) == "" {
+		return GroupSettings{}, errors.New("group_id required")
+	}
+	name, err := u.groups.GetName(ctx, groupID)
+	if err != nil {
+		return GroupSettings{}, err
+	}
+	h, err := u.groups.GetRefreshIntervalHours(ctx, groupID)
+	if err != nil {
+		return GroupSettings{}, err
+	}
+	return GroupSettings{GroupID: groupID, GroupName: name, RefreshIntervalHours: h}, nil
+}
+
+// --- update (new) ---
+
+func (u *groupSettingsUsecase) Update(ctx context.Context, in UpdateGroupSettingsInput, actorUserID string) (GroupSettings, error) {
+	if strings.TrimSpace(in.GroupID) == "" {
+		return GroupSettings{}, errors.New("group_id required")
+	}
+	// TODO: actorUserID の権限チェックを加えるならここで
+
+	if in.GroupName == nil && in.RefreshIntervalHours == nil {
+		return GroupSettings{}, errors.New("no_fields_to_update")
+	}
+
+	// name
+	if in.GroupName != nil {
+		n := strings.TrimSpace(*in.GroupName)
+		if n == "" {
+			return GroupSettings{}, errors.New("group_name required")
+		}
+		if utf8.RuneCountInString(n) > 50 {
+			return GroupSettings{}, errors.New("group_name too long")
+		}
+		if err := u.groups.UpdateName(ctx, in.GroupID, n); err != nil {
+			return GroupSettings{}, err
+		}
+	}
+
+	// hours
+	if in.RefreshIntervalHours != nil {
+		if !isAllowed(*in.RefreshIntervalHours) {
+			return GroupSettings{}, errors.New("refresh_interval_hours must be one of [12,24,48,72,96,120,144,168]")
+		}
+		if err := u.groups.UpdateRefreshIntervalHours(ctx, in.GroupID, *in.RefreshIntervalHours); err != nil {
+			return GroupSettings{}, err
+		}
+	}
+
+	// 最新値を返す
+	name, err := u.groups.GetName(ctx, in.GroupID)
+	if err != nil {
+		return GroupSettings{}, err
+	}
+	h, err := u.groups.GetRefreshIntervalHours(ctx, in.GroupID)
+	if err != nil {
+		return GroupSettings{}, err
+	}
+	return GroupSettings{GroupID: in.GroupID, GroupName: name, RefreshIntervalHours: h}, nil
+}
+
+// --- 互換API ---
 
 func (u *groupSettingsUsecase) GetHours(ctx context.Context, groupID string) (int, error) {
 	return u.groups.GetRefreshIntervalHours(ctx, groupID)
@@ -29,7 +116,6 @@ func (u *groupSettingsUsecase) UpdateHours(ctx context.Context, groupID string, 
 	if !isAllowed(hours) {
 		return 0, errors.New("refresh_interval_hours must be one of [12,24,48,72,96,120,144,168]")
 	}
-	// TODO: actorUserID が owner/admin か確認したい場合はここでチェック
 	if err := u.groups.UpdateRefreshIntervalHours(ctx, groupID, hours); err != nil {
 		return 0, err
 	}

--- a/db/init.sql
+++ b/db/init.sql
@@ -47,3 +47,11 @@ CREATE TABLE IF NOT EXISTS sessions (
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions (expires_at);
 CREATE INDEX IF NOT EXISTS idx_sessions_user_id   ON sessions (user_id);
+
+-- 現在の閲覧グループ
+CREATE TABLE IF NOT EXISTS user_active_groups (
+  user_id    UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  group_id   UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_user_active_groups_group ON user_active_groups(group_id);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   web:
     build: ./web
     ports:
-      - "3001:3000"
+      - "3000:3000"
     volumes:
       - ./web:/app
     environment:

--- a/web/src/app/groups/[groupId]/manage/page.tsx
+++ b/web/src/app/groups/[groupId]/manage/page.tsx
@@ -9,92 +9,70 @@ import GroupSettingsChangeSection from "@/components/GroupSettingsChangeSection"
 import GroupDangerZoneSection from "@/components/GroupDangerZoneSection";
 import Footer from "@/components/footer/Footer";
 
-type PageProps = {
-  params: Promise<{ groupId: string }>;
-};
+type PageProps = { params: Promise<{ groupId: string }> };
+
+type FrequencyKey = "12h" | "1d" | "2d" | "3d" | "4d" | "5d" | "6d" | "7d";
 
 type GroupInfo = {
   id: string;
   name: string;
-  updateFrequency: string;
+  updateFrequencyKey: FrequencyKey;
   isOwner: boolean;
+};
+
+const keyToHours: Record<FrequencyKey, number> = {
+  "12h": 12, "1d": 24, "2d": 48, "3d": 72, "4d": 96, "5d": 120, "6d": 144, "7d": 168,
+};
+const hoursToKey = (h?: number): FrequencyKey => {
+  const m: Record<number, FrequencyKey> = { 12:"12h",24:"1d",48:"2d",72:"3d",96:"4d",120:"5d",144:"6d",168:"7d" };
+  return m[h ?? 24] ?? "1d";
 };
 
 export default function GroupManagementPage({ params }: PageProps) {
   const { groupId } = use(params);
   const router = useRouter();
 
+  const [groupInfo, setGroupInfo] = useState<GroupInfo | null>(null);
+  const [editedGroupName, setEditedGroupName] = useState("");
+  const [editedFrequencyKey, setEditedFrequencyKey] = useState<FrequencyKey>("1d");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+
   useEffect(() => {
     if (!groupId) return;
-    const body = JSON.stringify({ group_id: groupId });
     fetch("/api/v1/groups/now", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       credentials: "include",
-      body,
-    });
+      body: JSON.stringify({ group_id: groupId }),
+    }).catch(() => {});
   }, [groupId]);
-
-  const [groupInfo, setGroupInfo] = useState<GroupInfo | null>(null);
-  const [editedGroupName, setEditedGroupName] = useState("");
-  const [editedFrequency, setEditedFrequency] = useState("1d");
-  const [isLoading, setIsLoading] = useState(true);
-
-  //日時変換
-  const hoursToFreq = (h?: number) => {
-    if (!h) return "1d";
-    if (h === 24) return "1d";
-    if (h === 72) return "3d";
-    if (h === 168) return "7d";
-    return `${h}h`;
-  };
 
   useEffect(() => {
     const load = async () => {
       setIsLoading(true);
       try {
-        // 設定情報
-        const res = await fetch(`/api/v1/groups/settings?group_id=${groupId}`, {
-          credentials: "include",
-        });
+        const res = await fetch(`/api/v1/groups/settings?group_id=${groupId}`, { credentials: "include" });
         if (!res.ok) throw new Error(String(res.status));
-        const json = await res.json();
+        const j = await res.json();
 
-        // ★ ここがポイント：まず settings から、無ければ users/list から名前を解決
-        let resolvedName: string | null = json.name ?? json.group_name ?? null;
-        if (!resolvedName) {
-          const listRes = await fetch(`/api/v1/users/list?limit=100&offset=0`, {
-            credentials: "include",
-          });
-          if (listRes.ok) {
-            const data = await listRes.json();
-            const hit = Array.isArray(data?.groups)
-              ? data.groups.find((g: any) => g.group_id === groupId)
-              : null;
-            if (hit?.name) resolvedName = hit.name as string;
-          }
-        }
+        const name = String(j.group_name ?? j.name ?? j.groupName ?? "チーム");
+        const hours = Number(j.refresh_interval_hours ?? j.hours ?? 24);
 
-        const next: GroupInfo = {
-          id: json.id ?? groupId,
-          name: resolvedName ?? "チーム",
-          updateFrequency: json.update_frequency ?? "1d",
-          isOwner: Boolean(json.is_owner ?? json.is_admin ?? false),
-        };
-
-        setGroupInfo(next);
-        setEditedGroupName(next.name);
-        setEditedFrequency(next.updateFrequency);
-      } catch {
-        const fallback: GroupInfo = {
+        const info: GroupInfo = {
           id: groupId,
-          name: "チーム",
-          updateFrequency: "1d",
-          isOwner: false,
+          name,
+          updateFrequencyKey: hoursToKey(hours),
+          isOwner: true, // 必要なら別APIで厳密化
         };
+        setGroupInfo(info);
+        setEditedGroupName(info.name);
+        setEditedFrequencyKey(info.updateFrequencyKey);
+      } catch {
+        const fallback: GroupInfo = { id: groupId, name: "チーム", updateFrequencyKey: "1d", isOwner: false };
         setGroupInfo(fallback);
         setEditedGroupName(fallback.name);
-        setEditedFrequency(fallback.updateFrequency);
+        setEditedFrequencyKey(fallback.updateFrequencyKey);
       } finally {
         setIsLoading(false);
       }
@@ -102,12 +80,37 @@ export default function GroupManagementPage({ params }: PageProps) {
     load();
   }, [groupId]);
 
-
-  const handleUpdateSettings = () => {
-    alert(`設定を更新: ${editedGroupName}`);
+  const handleSave = async () => {
+    if (!groupInfo) return;
+    setIsSaving(true);
+    try {
+      const payload = {
+        group_id: groupInfo.id,
+        group_name: editedGroupName,
+        refresh_interval_hours: keyToHours[editedFrequencyKey],
+      };
+      const res = await fetch("/api/v1/groups/settings/update", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify(payload),
+      });
+      const text = await res.text();
+      if (!res.ok) {
+        alert(`更新に失敗しました（${res.status}）\n${text}`);
+        return;
+      }
+      setGroupInfo(prev => prev ? { ...prev, name: editedGroupName, updateFrequencyKey: editedFrequencyKey } : prev);
+      alert("保存しました");
+      router.refresh();
+    } catch {
+      alert("通信エラーが発生しました");
+    } finally {
+      setIsSaving(false);
+    }
   };
 
-  const handleLeaveGroup = async() => {
+  const handleLeave = async () => {
     if (!confirm("本当に脱退しますか？")) return;
     setIsLoading(true);
     try {
@@ -132,7 +135,7 @@ export default function GroupManagementPage({ params }: PageProps) {
     }
   };
 
-  const handleDeleteGroup = async () => {
+  const handleDelete = async () => {
     if (!confirm("本当に削除しますか？この操作は元に戻せません。")) return;
     setIsLoading(true);
     try {
@@ -144,9 +147,7 @@ export default function GroupManagementPage({ params }: PageProps) {
       });
       if (!res.ok) {
         const msg = await res.text();
-        const human =
-          res.status === 403 ? "削除権限がありません。" : `削除に失敗しました（${res.status}）`;
-        alert(`${human}\n${msg}`);
+        alert(`削除に失敗しました（${res.status}）\n${msg}`);
         setIsLoading(false);
         return;
       }
@@ -162,9 +163,7 @@ export default function GroupManagementPage({ params }: PageProps) {
   if (isLoading || !groupInfo) {
     return (
       <div className="fixed inset-0 bg-white bg-opacity-50 flex items-center justify-center">
-        <div className="bg-white rounded-lg p-4">
-          <p>読み込み中...</p>
-        </div>
+        <div className="bg-white rounded-lg p-4"><p>読み込み中...</p></div>
       </div>
     );
   }
@@ -173,7 +172,6 @@ export default function GroupManagementPage({ params }: PageProps) {
     <div className="bg-white min-h-screen">
       <div className="px-4 pb-8">
         <ModalHeader />
-
         <div className="text-center">
           <h1 className="text-2xl font-bold text-black">{groupInfo.name}</h1>
         </div>
@@ -184,15 +182,15 @@ export default function GroupManagementPage({ params }: PageProps) {
           <GroupSettingsChangeSection
             groupName={editedGroupName}
             onNameChange={(e) => setEditedGroupName(e.target.value)}
-            frequency={editedFrequency}
-            onFrequencyChange={(e) => setEditedFrequency(e.target.value)}
-            onSubmit={handleUpdateSettings}
+            frequency={editedFrequencyKey}
+            onFrequencyChange={(e) => setEditedFrequencyKey(e.target.value as FrequencyKey)}
+            onSubmit={handleSave}
           />
 
           <GroupDangerZoneSection
             isOwner={groupInfo.isOwner}
-            onLeave={handleLeaveGroup}
-            onDelete={handleDeleteGroup}
+            onLeave={handleLeave}
+            onDelete={handleDelete}
           />
         </main>
 

--- a/web/src/app/groups/[groupId]/manage/page.tsx
+++ b/web/src/app/groups/[groupId]/manage/page.tsx
@@ -61,7 +61,7 @@ export default function GroupManagementPage({ params }: PageProps) {
   const handleUpdateSettings = () => {
     alert(`設定を更新: ${editedGroupName}`);
   };
-  
+
   const handleLeaveGroup = async() => {
     if (!confirm("本当に脱退しますか？")) return;
     setIsLoading(true);
@@ -87,8 +87,31 @@ export default function GroupManagementPage({ params }: PageProps) {
     }
   };
 
-  const handleDeleteGroup = () => {
-    if (confirm("本当に削除しますか？")) alert("削除しました");
+  const handleDeleteGroup = async () => {
+    if (!confirm("本当に削除しますか？この操作は元に戻せません。")) return;
+    setIsLoading(true);
+    try {
+      const res = await fetch("/api/v1/groups/delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ group_id: groupId }),
+      });
+      if (!res.ok) {
+        const msg = await res.text();
+        const human =
+          res.status === 403 ? "削除権限がありません。" : `削除に失敗しました（${res.status}）`;
+        alert(`${human}\n${msg}`);
+        setIsLoading(false);
+        return;
+      }
+      await fetch("/api/v1/groups/now", { method: "DELETE", credentials: "include" });
+      router.push("/groups");
+      router.refresh();
+    } catch {
+      alert("通信エラーが発生しました");
+      setIsLoading(false);
+    }
   };
 
   if (isLoading || !groupInfo) {

--- a/web/src/app/groups/[groupId]/manage/page.tsx
+++ b/web/src/app/groups/[groupId]/manage/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, use } from "react";
 import { useRouter } from "next/navigation";
 
 import ModalHeader from "@/components/ModalHeader";
@@ -10,7 +10,7 @@ import GroupDangerZoneSection from "@/components/GroupDangerZoneSection";
 import Footer from "@/components/footer/Footer";
 
 type PageProps = {
-  params: { groupId: string };
+  params: Promise<{ groupId: string }>;
 };
 
 type GroupInfo = {
@@ -21,7 +21,7 @@ type GroupInfo = {
 };
 
 export default function GroupManagementPage({ params }: PageProps) {
-  const { groupId } = params;
+  const { groupId } = use(params);
   const router = useRouter();
 
   useEffect(() => {
@@ -40,23 +40,68 @@ export default function GroupManagementPage({ params }: PageProps) {
   const [editedFrequency, setEditedFrequency] = useState("1d");
   const [isLoading, setIsLoading] = useState(true);
 
+  //日時変換
+  const hoursToFreq = (h?: number) => {
+    if (!h) return "1d";
+    if (h === 24) return "1d";
+    if (h === 72) return "3d";
+    if (h === 168) return "7d";
+    return `${h}h`;
+  };
+
   useEffect(() => {
-    const fetchGroupInfo = async () => {
+    const load = async () => {
       setIsLoading(true);
-      const dummyData: GroupInfo = {
-        id: groupId,
-        name: "ひよこさんチーム",
-        updateFrequency: "1d",
-        isOwner: true,
-      };
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      setGroupInfo(dummyData);
-      setEditedGroupName(dummyData.name);
-      setEditedFrequency(dummyData.updateFrequency);
-      setIsLoading(false);
+      try {
+        // 設定情報
+        const res = await fetch(`/api/v1/groups/settings?group_id=${groupId}`, {
+          credentials: "include",
+        });
+        if (!res.ok) throw new Error(String(res.status));
+        const json = await res.json();
+
+        // ★ ここがポイント：まず settings から、無ければ users/list から名前を解決
+        let resolvedName: string | null = json.name ?? json.group_name ?? null;
+        if (!resolvedName) {
+          const listRes = await fetch(`/api/v1/users/list?limit=100&offset=0`, {
+            credentials: "include",
+          });
+          if (listRes.ok) {
+            const data = await listRes.json();
+            const hit = Array.isArray(data?.groups)
+              ? data.groups.find((g: any) => g.group_id === groupId)
+              : null;
+            if (hit?.name) resolvedName = hit.name as string;
+          }
+        }
+
+        const next: GroupInfo = {
+          id: json.id ?? groupId,
+          name: resolvedName ?? "チーム",
+          updateFrequency: json.update_frequency ?? "1d",
+          isOwner: Boolean(json.is_owner ?? json.is_admin ?? false),
+        };
+
+        setGroupInfo(next);
+        setEditedGroupName(next.name);
+        setEditedFrequency(next.updateFrequency);
+      } catch {
+        const fallback: GroupInfo = {
+          id: groupId,
+          name: "チーム",
+          updateFrequency: "1d",
+          isOwner: false,
+        };
+        setGroupInfo(fallback);
+        setEditedGroupName(fallback.name);
+        setEditedFrequency(fallback.updateFrequency);
+      } finally {
+        setIsLoading(false);
+      }
     };
-    fetchGroupInfo();
+    load();
   }, [groupId]);
+
 
   const handleUpdateSettings = () => {
     alert(`設定を更新: ${editedGroupName}`);

--- a/web/src/app/groups/[groupId]/manage/page.tsx
+++ b/web/src/app/groups/[groupId]/manage/page.tsx
@@ -1,20 +1,17 @@
 "use client";
 
-import { useState, useEffect, use } from "react";
-import { useRouter } from 'next/navigation';
+import { useState, useEffect } from "react";
 
-// 必要なコンポーネントをインポート
 import ModalHeader from "@/components/ModalHeader";
-import AppLogo from "@/components/AppLogo";
 import GroupIdSection from "@/components/GroupIdSection";
 import GroupSettingsChangeSection from "@/components/GroupSettingsChangeSection";
 import GroupDangerZoneSection from "@/components/GroupDangerZoneSection";
 import Footer from "@/components/footer/Footer";
 
-// 型定義
 type PageProps = {
   params: { groupId: string };
 };
+
 type GroupInfo = {
   id: string;
   name: string;
@@ -23,41 +20,51 @@ type GroupInfo = {
 };
 
 export default function GroupManagementPage({ params }: PageProps) {
-  const router = useRouter();
-  const { groupId } = use(params);
+  const { groupId } = params;
 
-  // 状態管理
+  useEffect(() => {
+    if (!groupId) return;
+    const body = JSON.stringify({ group_id: groupId });
+    fetch("/api/v1/groups/now", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body,
+    });
+  }, [groupId]);
+
   const [groupInfo, setGroupInfo] = useState<GroupInfo | null>(null);
   const [editedGroupName, setEditedGroupName] = useState("");
   const [editedFrequency, setEditedFrequency] = useState("1d");
   const [isLoading, setIsLoading] = useState(true);
 
-  // データ取得
   useEffect(() => {
     const fetchGroupInfo = async () => {
       setIsLoading(true);
-      // ダミーデータ
       const dummyData: GroupInfo = {
         id: groupId,
         name: "ひよこさんチーム",
         updateFrequency: "1d",
         isOwner: true,
       };
-      await new Promise(resolve => setTimeout(resolve, 500));
-
+      await new Promise((resolve) => setTimeout(resolve, 500));
       setGroupInfo(dummyData);
       setEditedGroupName(dummyData.name);
       setEditedFrequency(dummyData.updateFrequency);
       setIsLoading(false);
     };
-
     fetchGroupInfo();
   }, [groupId]);
 
-  // イベントハンドラ
-  const handleUpdateSettings = () => { alert(`設定を更新: ${editedGroupName}`); };
-  const handleLeaveGroup = () => { if (confirm("本当に脱退しますか？")) alert("脱退しました"); };
-  const handleDeleteGroup = () => { if (confirm("本当に削除しますか？")) alert("削除しました"); };
+  const handleUpdateSettings = () => {
+    alert(`設定を更新: ${editedGroupName}`);
+  };
+  const handleLeaveGroup = () => {
+    if (confirm("本当に脱退しますか？")) alert("脱退しました");
+  };
+  const handleDeleteGroup = () => {
+    if (confirm("本当に削除しますか？")) alert("削除しました");
+  };
 
   if (isLoading || !groupInfo) {
     return (
@@ -72,11 +79,8 @@ export default function GroupManagementPage({ params }: PageProps) {
   return (
     <div className="bg-white min-h-screen">
       <div className="px-4 pb-8">
-        
-        {/* 1. settingページと同じModalHeaderを使用 */}
         <ModalHeader />
-        
-        {/* 2. 中央揃えのタイトルを追加 */}
+
         <div className="text-center">
           <h1 className="text-2xl font-bold text-black">{groupInfo.name}</h1>
         </div>
@@ -91,13 +95,14 @@ export default function GroupManagementPage({ params }: PageProps) {
             onFrequencyChange={(e) => setEditedFrequency(e.target.value)}
             onSubmit={handleUpdateSettings}
           />
-          
+
           <GroupDangerZoneSection
             isOwner={groupInfo.isOwner}
             onLeave={handleLeaveGroup}
             onDelete={handleDeleteGroup}
           />
         </main>
+
         <Footer />
       </div>
     </div>

--- a/web/src/app/groups/[groupId]/manage/page.tsx
+++ b/web/src/app/groups/[groupId]/manage/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 import ModalHeader from "@/components/ModalHeader";
 import GroupIdSection from "@/components/GroupIdSection";
@@ -21,6 +22,7 @@ type GroupInfo = {
 
 export default function GroupManagementPage({ params }: PageProps) {
   const { groupId } = params;
+  const router = useRouter();
 
   useEffect(() => {
     if (!groupId) return;
@@ -59,9 +61,32 @@ export default function GroupManagementPage({ params }: PageProps) {
   const handleUpdateSettings = () => {
     alert(`設定を更新: ${editedGroupName}`);
   };
-  const handleLeaveGroup = () => {
-    if (confirm("本当に脱退しますか？")) alert("脱退しました");
+  
+  const handleLeaveGroup = async() => {
+    if (!confirm("本当に脱退しますか？")) return;
+    setIsLoading(true);
+    try {
+      const res = await fetch("/api/v1/groups/leave", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ group_id: groupId }),
+      });
+      if (!res.ok) {
+        const msg = await res.text();
+        alert(`脱退に失敗しました（${res.status}）\n${msg}`);
+        setIsLoading(false);
+        return;
+      }
+      await fetch("/api/v1/groups/now", { method: "DELETE", credentials: "include" });
+      router.push("/groups");
+      router.refresh();
+    } catch {
+      alert("通信エラーが発生しました");
+      setIsLoading(false);
+    }
   };
+
   const handleDeleteGroup = () => {
     if (confirm("本当に削除しますか？")) alert("削除しました");
   };

--- a/web/src/app/groups/[groupId]/page.tsx
+++ b/web/src/app/groups/[groupId]/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+import { useEffect, useState } from "react";
 import GroupPageHeader from '@/components/GroupPageHeader';
 import MusicPlayer from '@/components/MusicPlayer';
 import UpdateCountdown from '@/components/UpdateCountdown';
@@ -9,63 +11,73 @@ type PageProps = {
   params: { groupId: string };
 };
 
-// サーバーサイドでデータを取得する非同期関数
-// TODO: 実際にはここでGoバックエンドのAPIをfetchします
-async function getGroupData(groupId: string) {
-  // --- ダミーデータ ---
-  // APIから取得するデータの例
-  const dummyData = {
-    groupName: 'ひよこさんチーム',
-    spotifyTrackId: '003vvx7Niy0yvhvHt4a68B', // 米津玄師 - LOSER のID
-    daysUntilUpdate: 3,
-    // 👇 メンバー10人分のエナジーレベル配列に変更
-    memberEnergyLevels: [4, 2, 1, 3, 4, 3, 2, 1, 4, 3],
-  };
-  // --- ここまで ---
+type GroupData = {
+  groupName: string;
+  spotifyTrackId: string;
+  daysUntilUpdate: number;
+  memberEnergyLevels: number[];
+};
 
-  // API連携の実装例:
-  // const res = await fetch(`http://localhost:8080/api/groups/${groupId}`);
-  // if (!res.ok) {
-  //   throw new Error('Failed to fetch group data');
-  // }
-  // const data = await res.json();
-  // return data;
-
-  return dummyData;
-}
-
-export default async function GroupPlayPage({ params }: PageProps) {
-  // URLの[groupId]を取得
+export default function GroupDetailPage({ params }: PageProps) {
   const { groupId } = params;
 
-  // データを取得
-  const groupData = await getGroupData(groupId);
+  const [data, setData] = useState<GroupData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // アクティブグループ登録
+  useEffect(() => {
+    const body = JSON.stringify({ group_id: groupId });
+    fetch("/api/v1/groups/now", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body,
+    }).catch(() => {});
+  }, [groupId]);
+
+  // データ取得（必要に応じてBEのAPIに差し替え）
+  useEffect(() => {
+    async function load() {
+      setLoading(true);
+      try {
+        // TODO: 実APIに置き換える
+        // const res = await fetch(`/api/v1/groups/${groupId}`, { credentials: "include" });
+        // if (!res.ok) throw new Error(String(res.status));
+        // const json = await res.json();
+
+        const json: GroupData = {
+          groupName: "ひよこさんチーム",
+          spotifyTrackId: "003vvx7Niy0yvhvHt4a68B",
+          daysUntilUpdate: 3,
+          memberEnergyLevels: [4, 2, 1, 3, 4, 3, 2, 1, 4, 3],
+        };
+        setData(json);
+      } catch {
+        setData(null);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [groupId]);
+
+  if (loading || !data) {
+    return <div className="p-4">読み込み中...</div>;
+  }
 
   return (
     <div className="relative flex flex-col items-center min-h-screen bg-white text-gray-800 pt-20 pb-40">
-      {/* ヘッダー */}
-      <GroupPageHeader groupId={groupId} groupName={groupData.groupName} />
+      <GroupPageHeader groupId={groupId} groupName={data.groupName} />
 
       <main className="w-full max-w-lg px-6 flex flex-col items-center gap-8">
-        {/* ページタイトル */}
         <h2 className="text-2xl font-bold">Energy Song</h2>
-
-        {/* 音楽プレーヤー */}
-        <MusicPlayer trackId={groupData.spotifyTrackId} />
-
-        {/* 更新カウントダウン */}
+        <MusicPlayer trackId={data.spotifyTrackId} />
         <div className="w-full flex justify-end">
-          <UpdateCountdown daysLeft={groupData.daysUntilUpdate} />
+          <UpdateCountdown daysLeft={data.daysUntilUpdate} />
         </div>
-
-        {/* エネルギー表示 (渡すpropを変更) */}
-        <EnergyDisplay energyLevels={groupData.memberEnergyLevels} />
+        <EnergyDisplay energyLevels={data.memberEnergyLevels} />
       </main>
 
-      {/* フッターは別で作成されているとのことなので、
-        ここにそのコンポーネントを配置してください。
-        例: <Footer /> 
-      */}
       <Footer />
     </div>
   );

--- a/web/src/app/groups/page.tsx
+++ b/web/src/app/groups/page.tsx
@@ -12,6 +12,12 @@ export default function GroupListPage() {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    const initActiveGroup = async () => {
+      try {
+        await fetch('/api/v1/groups/now', { method: 'DELETE', credentials: 'include' });
+      } catch {}
+    };
+
     const fetchGroups = async () => {
       setIsLoading(true);
       try {
@@ -44,7 +50,7 @@ export default function GroupListPage() {
       }
     };
 
-    fetchGroups();
+    initActiveGroup().finally(fetchGroups);
   }, []);
 
   return (


### PR DESCRIPTION
**グループの把握**
やったこと
- DB作成：user_active_groups
- グループ一覧ページ
　DELETE /api/v1/groups/now
　　DBから自分のuser_idが含まれている行を削除（アクティブなページの削除）
- グループ詳細ページ
　POST /api/v1/groups/now
　　DBにログインユーザーが見ているページのグループを登録
- グループ設定ページ
　POST /api/v1/groups/now
　　DBにログインユーザーが見ているページのグループを登録
確認してほしいこと
- Webページの形が崩れていないか
- ログインユーザーがブラウザで見ているグループの情報がDBに存在するか
- 再び/groupsにアクセスした際に、自分が見ていたグループの情報が消えているか(他人のが消えたらマズイ)

つなぎこみ
slackの通りに確認おねがいします